### PR TITLE
fix:napcat compatibility

### DIFF
--- a/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/event/raw/Sender.kt
+++ b/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/event/raw/Sender.kt
@@ -38,7 +38,7 @@ public data class PrivateSender(
     /**
      * 性别
      */
-    val sex: UserSex,
+    val sex: UserSex?,
     /**
      * 年龄
      */


### PR DESCRIPTION
NapCat 中的 private message 事件里似乎并不会传递发送者的性别数据

```
kotlinx.serialization.MissingFieldException: Field 'sex' is required for type with serial name 'cn.rtast.rob.event.raw.PrivateSender', but it was missing at path: $.sender
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:95)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:43)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableElement(AbstractDecoder.kt:70)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableElement(StreamingJsonDecoder.kt:168)
	at cn.rtast.rob.event.raw.message.PrivateMessage$$serializer.deserialize(Message.kt:300)
	at cn.rtast.rob.event.raw.message.PrivateMessage$$serializer.deserialize(Message.kt:300)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:69)
	at kotlinx.serialization.json.Json.decodeFromString(Json.kt:149)
	at cn.rtast.rob.util.MessageHandler.onMessage$ronebot_onebot_v11(MessageHandler.kt:472)
	at cn.rtast.rob.util.ws.ProcessingIncomingMessageKt$processIncomingMessage$1.invokeSuspend(ProcessingIncomingMessage.kt:32)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
Caused by: kotlinx.serialization.MissingFieldException: Field 'sex' is required for type with serial name 'cn.rtast.rob.event.raw.PrivateSender', but it was missing
	at kotlinx.serialization.internal.PluginExceptionsKt.throwMissingFieldException(PluginExceptions.kt:20)
	at cn.rtast.rob.event.raw.PrivateSender.<init>(Sender.kt:27)
	at cn.rtast.rob.event.raw.PrivateSender$$serializer.deserialize(Sender.kt:27)
	at cn.rtast.rob.event.raw.PrivateSender$$serializer.deserialize(Sender.kt:27)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:69)
	... 17 more
```