### PR TITLE
add downloadFile api

### DIFF
--- a/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/api/set/DownloadFileApi.kt
+++ b/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/api/set/DownloadFileApi.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2025 RTAkland & 小满1221
+ * Date: 6/23/25, 4:36 AM
+ * Open Source Under Apache-2.0 License
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+@file:OptIn(ExperimentalUuidApi::class)
+
+package cn.rtast.rob.api.set
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@Serializable
+internal data class DownloadFileApi(
+    val params: Params,
+    val action: String = "download_file",
+    val echo: Uuid
+) {
+    @Serializable
+    data class Params(
+        val url: String,
+        @SerialName("thread_count")
+        val threadCount: Int?,
+        val headers: String?
+    )
+}

--- a/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/event/raw/file/DownloadFileResponse.kt
+++ b/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/event/raw/file/DownloadFileResponse.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2025 RTAkland & 小满1221
+ * Date: 6/23/25, 4:39 AM
+ * Open Source Under Apache-2.0 License
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package cn.rtast.rob.event.raw.file
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class DownloadFileResponse(
+    val data: DownloadFileResponseInfo
+) {
+    @Serializable
+    public data class DownloadFileResponseInfo(
+        val file: String
+    )
+}

--- a/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/event/raw/file/RawFileEvent.kt
+++ b/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/event/raw/file/RawFileEvent.kt
@@ -49,7 +49,7 @@ public data class RawFileEvent(
         val id: String,
         val name: String,
         val size: Int,
-        val url: String,
+        val url: String?,
         @SerialName("busid")
         val busId: Long,
     )
@@ -74,8 +74,9 @@ public data class RawFileEvent(
 
     @JvmBlocking(suffix = "JvmBlocking")
     override suspend fun readBytes(): ByteArray {
+        val url = this@RawFileEvent.file.url ?: error("not found url in RawFileEvent.File")
         return withContext(Dispatchers.Default) {
-            readBytes(this@RawFileEvent.file.url)
+            readBytes(url)
         }
     }
 }

--- a/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/onebot/OneBotAction.kt
+++ b/ronebot-onebot-v11/src/commonMain/kotlin/cn/rtast/rob/onebot/OneBotAction.kt
@@ -1836,4 +1836,20 @@ public class OneBotAction internal constructor(
             ).toJson()
         )
     }
+
+    /**
+     * 下载文件到缓存目录
+     * @param url 链接地址
+     * @param threadCount 下载线程数
+     * @param headers 自定义请求头，格式 User-Agent=YOUR_UA[\r\n]Referer=https://www.baidu.com
+     */
+    @JvmOverloads
+    @JvmBlocking(suffix = "JvmBlocking")
+    public suspend fun downloadFile(url: String, threadCount: Int? = null, headers: String? = null): DownloadFileResponse.DownloadFileResponseInfo {
+        val uuid = Uuid.random()
+        val deferred = this.createCompletableDeferred(uuid)
+        this.send(DownloadFileApi(DownloadFileApi.Params(url, threadCount, headers), echo = uuid).toJson())
+        val response = deferred.await()
+        return response.fromJson<DownloadFileResponse>().data
+    }
 }


### PR DESCRIPTION
1、添加一个`cqhttp`接口，https://docs.go-cqhttp.org/api/#%E4%B8%8B%E8%BD%BD%E6%96%87%E4%BB%B6%E5%88%B0%E7%BC%93%E5%AD%98%E7%9B%AE%E5%BD%95

2、使`RawFileEvent.File`的`url`可为`null`，在napcat中，机器人上传文件后会抛出异常，url为null
